### PR TITLE
LWSHADOOP-584: Hadoop projects improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,23 @@ solr-pig-functions/build/libs/{packageUser}-pig-functions-{connectorVersion}.jar
 
 The .jar is required to use Pig functions to index content to Solr.
 
+=== Troubleshooting
+
+If GitHub + SSH is not configured the following exception will be thrown:
+
+[source]
+----
+    Cloning into 'solr-hadoop-common'...
+    Permission denied (publickey).
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    fatal: clone of 'git@github.com:LucidWorks/solr-hadoop-common.git' into submodule path 'solr-hadoop-common' failed
+----
+
+Use the next tutorial to fix the exception: https://help.github.com/articles/generating-an-ssh-key/
+
 == Use the Functions
 
 // tag::functions[]

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ subprojects {
     dependencies {
     }
 
+    test {
+      reports.html.destination = file("$buildDir/reports/tests")
+      reports.junitXml.destination = file("$buildDir/test-results")
+    }
+
     jacocoTestReport {
       reports {
         xml.enabled false

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,15 @@ buildscript {
 }
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.2'
+  id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
 ext {
   publishedProjects = subprojects - project(':solr-hadoop-common')
+}
+
+task wrapper(type: Wrapper) {
+    gradleVersion = '3.0'
 }
 
 defaultTasks 'dist'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
# Related issues:

- LWSHADOOP-584: Build hadoop related projects
- LWSHADOOP-588: Update gradle version of hadoop related projects

# Changes:

- Add "Troubleshooting" to "Build the Functions Jar" section
- Add wrapper task to gradle build
- Upgrade gradle to 3.0