### PR TITLE
LWSHADOOP-703: Update to latest solr-hadoop-common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,26 @@ subprojects {
       mavenCentral()
     }
 
+    project.configurations {
+      hadoop2Compile.extendsFrom(project.configurations.compile)
+      hadoop2TestCompile.extendsFrom(project.configurations.testCompile)
+      hadoop2TestRuntime.extendsFrom(project.configurations.testRuntime)
+      it."default".extendsFrom(project.configurations.hadoop2Compile)
+    }
+
+    compileJava {
+      classpath = configurations.hadoop2Compile
+    }
+
+    compileTestJava {
+      classpath = configurations.hadoop2TestCompile + sourceSets.main.output
+    }
+
     dependencies {
     }
 
     test {
+      classpath = configurations.hadoop2TestRuntime + sourceSets.main.output + sourceSets.test.output
       reports.html.destination = file("$buildDir/reports/tests")
       reports.junitXml.destination = file("$buildDir/test-results")
     }
@@ -70,7 +86,7 @@ subprojects {
 
 project('solr-pig-core') {
   dependencies {
-    compile(project(':solr-hadoop-common:solr-hadoop-io')) {
+    hadoop2Compile(project(':solr-hadoop-common:solr-hadoop-io')) {
       transitive = false
     }
     compile("org.apache.pig:pig:${pigVersion}") {
@@ -85,18 +101,18 @@ project('solr-pig-core') {
     compile("org.apache.solr:solr-solrj:${solrVersion}") {
       exclude group: 'org.apache.hadoop'
     }
-    compile("org.apache.hadoop:hadoop-common:${hadoop2Version}@jar")
-    compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
+    hadoop2Compile("org.apache.hadoop:hadoop-common:${hadoop2Version}@jar")
+    hadoop2Compile("org.apache.hadoop:hadoop-client:${hadoop2Version}") {
       exclude group: 'log4j'
       exclude group: 'org.slf4j'
     }
-    compile("org.apache.hadoop:hadoop-auth:${hadoop2Version}") {
+    hadoop2Compile("org.apache.hadoop:hadoop-auth:${hadoop2Version}") {
       transitive = false
     }
-    compile("org.apache.hadoop:hadoop-mapreduce-client-core:${hadoop2Version}") {
+    hadoop2Compile("org.apache.hadoop:hadoop-mapreduce-client-core:${hadoop2Version}") {
       transitive = false
     }
-    compile("org.apache.hadoop:hadoop-hdfs:${hadoop2Version}@jar") {
+    hadoop2Compile("org.apache.hadoop:hadoop-hdfs:${hadoop2Version}@jar") {
       transitive = false
     }
 


### PR DESCRIPTION
The latest solr-hadoop-common brings in a newer Tika version, as well as
changing the way Hadoop deps are specified, to be more flexible for
consuming projects.